### PR TITLE
IRI Fixes

### DIFF
--- a/pages/iri/usage/install-iri-docker.mdx
+++ b/pages/iri/usage/install-iri-docker.mdx
@@ -1,6 +1,7 @@
 import { withRouter } from 'next/router'
 import WithMDX from '../../../lib/with-mdx'
 
+import { Code } from '../../../components/text/code'
 import { TerminalInput } from '../../../components/text/terminal'
 import { ExternalLink, InternalLink } from '../../../components/text/link'
 import { tyler } from '../../../lib/data/team'
@@ -37,7 +38,7 @@ Follow the official <ExternalLink href="https://docs.docker.com/install/#support
 
 Test the Docker installation by executing the following commands from a terminal session.
 
-  * Note: depending on how you have installed Docker, you may need to use the "sudo" command to execute Docker on Mac OSX or Linux platforms.
+  * Note: depending on how you have installed Docker, you may need to use the ```sudo``` command to execute Docker on Mac OSX or Linux platforms.
 
 <TerminalInput>{`docker run hello-world`}</TerminalInput>
 
@@ -67,7 +68,7 @@ docker build -t iri .`}</TerminalInput>
 
 Start the IRI node.
 
-  * Note: the "/path/to/data" in the following examples will be the path on your host where the tangle data will be stored persistently.
+  * Note: the ```/path/to/data``` in the following examples will be the path on your host where the tangle data will be stored persistently.
 
 ### Using the Prebuilt Docker Container from Dockerhub
 
@@ -93,9 +94,9 @@ To stop and remove the IRI container, execute the following commands.
 
 ### Restarting
 
-If you wish to have the IRI container start on every boot, add the following flag to the Docker "run" command.
+If you wish to have the IRI container start on every boot, add the following flag to the Docker ```run``` command.
 
-<TerminalInput>{`--restart=always`}</TerminalInput>
+<Code>{`--restart=always`}</Code>
 
 ### Port Mapping
 
@@ -116,18 +117,18 @@ curl -s http://localhost:14265 -X POST -H 'X-IOTA-API-Version: 1' -H 'Content-Ty
 
 The node can be configured by passing command line arguments to the IRI jar when invoked, however a configuration file can also be used.
 
-<TerminalInput>{`# Create an INI file like the one below, lets say iri.ini
+<Code>{`# Create an INI file like the one below, lets say iri.ini
 [IRI]
 PORT = 14265
 UDP_RECEIVER_PORT = 14600
 NEIGHBORS = udp://my.favorite-iri-node.com:14600
 IXI_DIR = ixi
 DEBUG = false
-DB_PATH = db`}</TerminalInput>
+DB_PATH = db`}</Code>
 
-A new mount point for this configuration file will need to be added to the Docker "run" command.
+A new mount point for this configuration file will need to be added to the Docker ```run``` command.
 
-<TerminalInput>{`-v /path/to/conf:/iri/conf`}</TerminalInput>
+<Code>{`-v /path/to/conf:/iri/conf`}</Code>
 
 For more detailed configuration options, please see the <ExternalLink href="https://github.com/iotaledger/iri/blob/dev/DOCKER.md" key="">IRI Docker Documentation</ExternalLink> on GitHub.
 

--- a/pages/iri/usage/install-iri-linux.mdx
+++ b/pages/iri/usage/install-iri-linux.mdx
@@ -107,6 +107,8 @@ An IRI JAVA archive (jar) has now been build in the "target" directory.
 
 Start the IRI node.
 
+  * Note: ```IRI_JAR_PATH``` must be the full path to the IRI JAVA archive. If you have built from source, then archive will be output in the ```target``` directory.
+
 <TerminalInput>{`export IRI_JAR_PATH=$pwd/target
 export JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+DisableAttachMechanism -XX:InitiatingHeapOccupancyPercent=60 -XX:G1MaxNewSizePercent=75 -XX:MaxGCPauseMillis=10000 -XX:+UseG1GC
 export JAVA_MIN_MEMORY=2G

--- a/pages/iri/usage/install-iri-linux.mdx
+++ b/pages/iri/usage/install-iri-linux.mdx
@@ -1,6 +1,7 @@
 import { withRouter } from 'next/router'
 import WithMDX from '../../../lib/with-mdx'
 
+import { Code } from '../../../components/text/code'
 import { TerminalInput } from '../../../components/text/terminal'
 import { ExternalLink, InternalLink } from '../../../components/text/link'
 import { tyler } from '../../../lib/data/team'
@@ -138,16 +139,16 @@ curl -s http://localhost:14265 -X POST -H 'X-IOTA-API-Version: 1' -H 'Content-Ty
 
 The node can be configured by passing command line arguments to the IRI jar when invoked, however a configuration file can also be used.
 
-<TerminalInput>{`# Create an INI file like the one below, lets say iri.ini
+<Code>{`# Create an INI file like the one below, lets say iri.ini
 [IRI]
 PORT = 14265
 UDP_RECEIVER_PORT = 14600
 NEIGHBORS = udp://my.favorite-iri-node.com:14600
 IXI_DIR = ixi
 DEBUG = false
-DB_PATH = db`}</TerminalInput>
+DB_PATH = db`}</Code>
 
-Now pass "-c iri.in" to the IRI jar when invoking:
+Now pass ```-c iri.ini``` to the IRI jar when invoking:
 
 <TerminalInput>{`java $JAVA_OPTIONS -Xms$JAVA_MIN_MEMORY -Xmx$JAVA_MAX_MEMORY -Djava.net.preferIPv4Stack=true -jar $IRI_JAR_PATH --remote -p 14265 -c iri.ini`}</TerminalInput>
 

--- a/pages/iri/usage/install-iri-linux.mdx
+++ b/pages/iri/usage/install-iri-linux.mdx
@@ -109,6 +109,7 @@ Start the IRI node.
 
 <TerminalInput>{`export IRI_JAR_PATH=$pwd/target
 export JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+DisableAttachMechanism -XX:InitiatingHeapOccupancyPercent=60 -XX:G1MaxNewSizePercent=75 -XX:MaxGCPauseMillis=10000 -XX:+UseG1GC
+export JAVA_MIN_MEMORY=2G
 export JAVA_MAX_MEMORY=4G
 # This path needs to adjusted for your local machine
 export IRI_JAR_PATH="$(pwd)/target/iri*.jar"


### PR DESCRIPTION
Various improvements suggested by folks after reading the guides.

  * Add missing JAVA ENV for minimum JAVA memory.
  * Clarify the IRI_JAR_PATH, and target directory.
  * Improve style by using code blocks for files and flags. Use markdown primitive instead of quotes.