### PR TITLE
jake-review

### DIFF
--- a/pages/compass/introduction/background.md
+++ b/pages/compass/introduction/background.md
@@ -12,7 +12,7 @@ editUrl: 'pages/compass/introduction/background.md',
 
 export default withRouter(props => WithMDX(props, page))
 
-An IOTA network relies on clients sending mostly honest transactions to IRI nodes and for those IRI nodes to propagate those transactions through the network. However, the fewer transactions that are propagated through an IOTA network, the easier it is for an attacker make IRI nodes propagate mostly dishonest transactions through the network.
+An IOTA network relies on clients sending mostly honest transactions to IRI nodes and for those IRI nodes to propagate those transactions through the network. However, the fewer transactions that are propagated through an IOTA network, the easier it is for an attacker to make the IRI nodes propagate mostly dishonest transactions through the network.
 
 If an attacker were to send the IRI nodes more dishonest transactions than the total number of honest transactions in an IOTA network, that attacker may be able to control the direction of consensus, double spend tokens, and carry out network-splitting attacks.
  

--- a/pages/compass/introduction/background.md
+++ b/pages/compass/introduction/background.md
@@ -12,19 +12,21 @@ editUrl: 'pages/compass/introduction/background.md',
 
 export default withRouter(props => WithMDX(props, page))
 
-The base assumption of the Tangle is that there are more honest than dishonest transactions propagating through the network. However, in the infancy of a Tangle there are less transactions propagated between nodes than maximum bandwidth between them.
+An IOTA network relies on clients sending mostly honest transactions to IRI nodes and for those IRI nodes to propagate those transactions through the network. However, the fewer transactions that are propagated through an IOTA network, the easier it is for an attacker make IRI nodes propagate mostly dishonest transactions through the network.
 
-The creators of the Tangle realized that if an attacker could publish more transactions than the total of the honest transactions, then they might control the direction of consensus. Thus, they could perform double spend and network splitting attacks.
+If an attacker were to send the IRI nodes more dishonest transactions than the total number of honest transactions in an IOTA network, that attacker may be able to control the direction of consensus, double spend tokens, and carry out network-splitting attacks.
  
-Enter the “Coordinator”, a temporary safety mechanism.  Such safety mechanisms are common in blockchain and DLT systems.  For example, Satoshi’s Bitcoin had hard-coded checkpoints plus an alerts system for him to shut down the network if necessary.
+Enter the Coordinator (COO): a temporary safety mechanism. Such safety mechanisms are common in blockchain and distributed ledger technology (DLT) systems. For example, Bitcoin had hard-coded checkpoints, plus an alerts system that allowed the creator to shut down the network if necessary.
  
-The Coordinator (COO) issues bundles at a regular interval. This bundle includes a signed transaction called a “milestone”.  When using a coordinator, such as Compass, transaction confirmation is achieved by determining if and only if, a transaction is referenced by a milestone directly or indirectly. At this point the transaction is considered confirmed by the nodes configured to recognize the coordinator. 
+COO sends bundles at regular intervals to the IRI nodes. These bundles include a signed transaction called a milestone. When using a COO such as Compass, the IRI nodes in an IOTA network consider a transaction as confirmed only if it's directly or indirectly referenced by a milestone.
 
-A Coordinator can be used to prevent attacks until the network can ensure a majority of honest transactions at which point it will hard to attack the consensus of the network.  At this point the Tangle, the use of a coordinator will no longer be required.
+**Note:** IRI nodes must be configured to recognize milestones that are published by Compass. 
+
+A COO such as Compass can be used to prevent attacks until mostly honest transactions are propagated through an IOTA network, at which point it will be hard to attack the consensus of the network and the use of a COO will no longer be required.
  
 ## Further Reading 
 
-To understand the requirement and use of a coordinator  there are a number of resources available:
+To learn more about the COO, read the following resources:
 - [IOTA Papers discussing the Tangle and other protocol features](https://www.iota.org/research/academic-papers)
 - [A series of posts discussing the removal of the Coordinator](https://blog.iota.org/coordinator-part-1-the-path-to-coordicide-ee4148a8db08)
 


### PR DESCRIPTION
If we are going to use the Tangle everywhere to refer to an IOTA network, we should be consistent. The last time I asked Lewis, he said that the Tangle is used to refer only to the mainnet network, in which case we shouldn't use the Tangle here, as the Compass is for creating private IOTA networks.

We should also be consistent with how we refer to transactions being sent to through the network. Are they sent through an IOTA network, published to an IOTA network, propagated through an IOTA network. Personally, we should use Plain English and say "send" when a client sends a transaction to a node (active voice). "Send a transaction to an IRI node", we should say propagate when we refer to the act of transactions being sent through each IRI node in a network (passive) "propagate through the network".

If we mention the acronym for the Coodinator (COO), we should use the acronym anywhere else to refer to the Coordinator.

Are we actively not using articles with Compass? Why do we not say "the compass". We say "the Tangle", "the Coodinator", "the IRI". It seems strange and inconsistent.