### PR TITLE
Reason for nodes running

### DIFF
--- a/pages/iri/what-is-iri.mdx
+++ b/pages/iri/what-is-iri.mdx
@@ -32,3 +32,4 @@ here: <ExternalLink href="https://github.com/iotaledger/iri" key="">https://gith
 ## Why run a Node? 
 
 It encourages decentralization of the network, and removes the need to trust a third party node to access the Tangle.
+Access to a running node is required to access the Tangle.


### PR DESCRIPTION
Access to a running node is required to access the Tangle.  I think it should be established as a requirement to either run a node or to get explicit allowance to access a specific node run by someone else.